### PR TITLE
Adds Anvil environments for mainnet and polygon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  anvil-mainnet:
+    build:
+      context: ./images
+      dockerfile: Dockerfile.anvil
+    environment:
+      - URL=${MAINNET_FORK_URL:-https://eth-mainnet.public.blastapi.io}
+    ports:
+      - "8545:8545"
+    networks:
+      - anvil-network
+
+  anvil-polygon:
+    build:
+      context: ./images
+      dockerfile: Dockerfile.anvil
+    environment:
+      - URL=${POLYGON_FORK_URL:-https://polygon-zkevm-mainnet.public.blastapi.io}
+    ports:
+      - "8546:8545"
+    networks:
+      - anvil-network
+
+networks:
+  anvil-network:
+    driver: bridge 

--- a/images/Dockerfile.anvil
+++ b/images/Dockerfile.anvil
@@ -1,0 +1,6 @@
+ # syntax=docker/dockerfile:1.4
+FROM ghcr.io/foundry-rs/foundry
+
+WORKDIR /anvil
+
+ENTRYPOINT anvil --fork-url $URL --host 0.0.0.0


### PR DESCRIPTION
Sets up Docker Compose to run Anvil instances that fork Ethereum mainnet and Polygon.

This allows for local testing and development against realistic blockchain states without deploying to live networks. Configures each instance with environment variables for the respective fork URLs.